### PR TITLE
Fix file tree icons on lower res devices

### DIFF
--- a/power-adapters-sample/src/main/res/drawable/file_icon_dir.xml
+++ b/power-adapters-sample/src/main/res/drawable/file_icon_dir.xml
@@ -8,5 +8,9 @@
         </shape>
     </item>
     <item android:drawable="@drawable/file_icon_symbol_dir"
-          android:gravity="center"/>
+          android:gravity="center"
+          android:top="4dp"
+          android:bottom="4dp"
+          android:right="4dp"
+          android:left="4dp"/>
 </layer-list>

--- a/power-adapters-sample/src/main/res/drawable/file_icon_file.xml
+++ b/power-adapters-sample/src/main/res/drawable/file_icon_file.xml
@@ -10,5 +10,9 @@
         </shape>
     </item>
     <item android:drawable="@drawable/file_icon_symbol_file"
-          android:gravity="center"/>
+          android:gravity="center"
+          android:top="4dp"
+          android:bottom="4dp"
+          android:right="4dp"
+          android:left="4dp"/>
 </layer-list>


### PR DESCRIPTION
Current:

![item-icon-broken](https://cloud.githubusercontent.com/assets/6470279/20289061/7ffc2cc4-ab27-11e6-8411-2c0e34e40f74.png)

With padding:

![item-icon-fixed](https://cloud.githubusercontent.com/assets/6470279/20289072/8b5f7094-ab27-11e6-8ce4-e49afae3a9a4.png)