### PR TITLE
Make RecyclerConverterAdapter's ViewHolder overrideable

### DIFF
--- a/power-adapters-recyclerview-v7/src/main/java/com/nextfaze/poweradapters/recyclerview/RecyclerConverterAdapter.java
+++ b/power-adapters-recyclerview-v7/src/main/java/com/nextfaze/poweradapters/recyclerview/RecyclerConverterAdapter.java
@@ -190,7 +190,7 @@ public class RecyclerConverterAdapter extends RecyclerView.Adapter<RecyclerConve
         return container;
     }
 
-    public static final class ViewHolder extends RecyclerView.ViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
 
         @NonNull
         final com.nextfaze.poweradapters.Holder holder = new com.nextfaze.poweradapters.Holder() {
@@ -203,13 +203,13 @@ public class RecyclerConverterAdapter extends RecyclerView.Adapter<RecyclerConve
         @NonNull
         final RecyclerViewContainer container;
 
-        ViewHolder(View itemView, @NonNull RecyclerViewContainer container) {
+        public ViewHolder(View itemView, @NonNull RecyclerViewContainer container) {
             super(itemView);
             this.container = container;
         }
     }
 
-    private final class RecyclerViewContainer extends Container {
+    protected final class RecyclerViewContainer extends Container {
 
         @NonNull
         private final OnAttachStateChangeListener mOnAttachStateChangeListener = new OnAttachStateChangeListener() {
@@ -227,7 +227,7 @@ public class RecyclerConverterAdapter extends RecyclerView.Adapter<RecyclerConve
         @NonNull
         private final RecyclerView mRecyclerView;
 
-        RecyclerViewContainer(@NonNull RecyclerView recyclerView) {
+        protected RecyclerViewContainer(@NonNull RecyclerView recyclerView) {
             mRecyclerView = recyclerView;
         }
 


### PR DESCRIPTION
This allows subclasses of RecyclerConverterAdapter to also use their own subclasses of RecyclerConverterAdapter.ViewHolder. This enables the use of AdvancedRecyclerView's (https://github.com/h6ah4i/android-advancedrecyclerview) drag-and-drop, which requires that ViewHolders implement a certain interface.